### PR TITLE
Add ability to download EURRUB rates using sample finam-download.py

### DIFF
--- a/finam/export.py
+++ b/finam/export.py
@@ -43,6 +43,7 @@ class Market(IntEnum):
 
     BONDS = 2
     COMMODITIES = 24
+    CURRENCIES_WORLD = 5
     CURRENCIES = 45
     ETF = 28
     ETF_MOEX = 515

--- a/scripts/finam-download.py
+++ b/scripts/finam-download.py
@@ -84,9 +84,10 @@ def main(contracts, market, timeframe, destdir, lineterm,
         raise click.BadParameter('Neither contracts nor market is specified')
 
     market_filter = dict()
-    if not contracts:
+    if market:
         market_filter.update(market=Market[market])
-        contracts = exporter.lookup(**market_filter)['code'].tolist()
+        if not contracts:
+            contracts = exporter.lookup(**market_filter)['code'].tolist()
 
     for contract_code in contracts:
         logging.info('Handling {}'.format(contract_code))


### PR DESCRIPTION
You will now be able to specify both market and contracts when calling finam-download.py that allows to resolve conflicts when you have the same contract in 2 different markets.
Pull request also adds a constant for CURRENCIES_WORLD.

Following script will now download daily EURRUB rates from 1 December of 1999:
python scripts/finam-download.py --contracts USDRUB,EURRUB --destdir ./data/ --startdate 1999-12-01 --market CURRENCIES_WORLD
